### PR TITLE
Update to allow multiple fab tasks

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,7 @@ test:
 
   override:
     - cd uat && packer build uat.json
+    - cd uat && packer build uat_multi.json
 
 general:
   artifacts:

--- a/provisioner.go
+++ b/provisioner.go
@@ -269,7 +269,10 @@ func (p *Provisioner) executeFabric(ui packer.Ui, comm packer.Communicator, priv
 		args = append(args, "--disable-known-hosts")
 	}
 	args = append(args, p.config.ExtraArguments...)
-	args = append(args, p.config.FabTasks)
+
+	for _,task := range strings.Split(p.config.FabTasks, ",") {
+	        args = append(args, task)
+	}
 
 	if len(p.config.FabricEnvVars) > 0 {
 		envvars = append(envvars, p.config.FabricEnvVars...)

--- a/uat/fabfile.py
+++ b/uat/fabfile.py
@@ -4,5 +4,6 @@ from fabric.api import *
 def test():
     run("echo \"This is a test\" >> test.txt")
 
+@task
 def test2():
     run("echo \"This is another test\" >> test.txt")

--- a/uat/fabfile.py
+++ b/uat/fabfile.py
@@ -3,3 +3,6 @@ from fabric.api import *
 @task
 def test():
     run("echo \"This is a test\" >> test.txt")
+
+def test2():
+    run("echo \"This is another test\" >> test.txt")

--- a/uat/uat_multi.json
+++ b/uat/uat_multi.json
@@ -1,0 +1,18 @@
+{
+  "builders": [{
+    "type": "amazon-ebs",
+    "source_ami": "ami-63b25203",
+    "region": "us-west-2",
+    "instance_type": "m3.medium",
+    "communicator": "ssh",
+    "ssh_username": "ec2-user",
+    "ami_name": "fabric-provisioner-uat-{{isotime \"20060102-150405\"}}",
+    "ami_description": "Automated acceptance test for Fabric provisioner",
+    "ami_virtualization_type": "hvm"
+  }],
+  "provisioners": [{
+    "type": "fabric",
+    "fab_file": "fabfile.py",
+    "fab_tasks": "test,test2"
+  }]
+}


### PR DESCRIPTION
fab_tasks passed in get passed in with quotes, so even if we have space separated list, this does not work as it is passed to fab with "param1 param2".  

Change made to split the string and add arguments separately.  So they will be added to fab as:  "param1" "param2".
