### PR TITLE
Adding fab_tasks_delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ The relative path to the fabfile to be utilized.
 
 Comma separated list of tasks to be executed.
 
+### fab_tasks_delimiter (optional)
+
+Specific delimiter for task list. Default is comma `,`.
+
 ### user (optional)
 
 SSH user to be used to connect to the SSH server on the host machine to forward commands to the target machine.

--- a/provisioner.go
+++ b/provisioner.go
@@ -44,6 +44,7 @@ type Config struct {
 	// The main Fab file to execute.
 	FabFile              string   `mapstructure:"fab_file"`
 	FabTasks             string   `mapstructure:"fab_tasks"`
+	FabTasksDelimiter    string   `mapstructure:"fab_tasks_delimiter"`
 	User                 string   `mapstructure:"user"`
 	LocalPort            string   `mapstructure:"local_port"`
 	SSHHostKeyFile       string   `mapstructure:"ssh_host_key_file"`
@@ -76,6 +77,11 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	// Defaults
 	if p.config.Command == "" {
 		p.config.Command = "fab"
+	}
+
+	// Fabric task delimiter
+	if p.config.FabTasksDelimiter == "" {
+		p.config.FabTasksDelimiter = ","
 	}
 
 	var errs *packer.MultiError
@@ -270,7 +276,7 @@ func (p *Provisioner) executeFabric(ui packer.Ui, comm packer.Communicator, priv
 	}
 	args = append(args, p.config.ExtraArguments...)
 
-	for _,task := range strings.Split(p.config.FabTasks, ",") {
+	for _,task := range strings.Split(p.config.FabTasks, p.config.FabTasksDelimiter) {
 	        args = append(args, task)
 	}
 


### PR DESCRIPTION
In order to correct https://github.com/unifio/packer-provisioner-fabric/issues/4, adding a new parameter to let user choose de tasks delimiter if needed.